### PR TITLE
Upgrade to v0.25.0 bin/hermit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,31 +31,14 @@ jobs:
           # Fetch all history for all tags and branches
           fetch-depth: 0
 
-      - name: Set env
+      - name: Set env, initialize Hermit
         run: |
           set -euxo pipefail
           # set RELEASE_VERSION as tag version
           echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
           echo "OS=$(echo $(uname -s) | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
           echo "ARCH=$(uname -m)" >> $GITHUB_ENV
-
-      - name: Download and validate sfsigner v0.0.0
-        run: |
-          set -euxo pipefail
-          cd ${{ github.workspace }}
-          mkdir -p dogfood
-          SFSIGNER0_URL="https://github.com/syncom/sf-signer/releases/download/v0.0.0/sfsigner-${OS}-${ARCH}"
-          SFSIGNER0_EXE="dogfood/sfsigner0"
-          echo "SFSIGNER0_EXE=${{ github.workspace }}/dogfood/sfsigner0" >> $GITHUB_ENV
-          curl -L "${SFSIGNER0_URL}" -o "${SFSIGNER0_EXE}"
-          # linux-x86_64
-          EXPECTED_SUM1="7cfd5c00b8bc7215bc99972017da1837c514856db6d72b8e44e9136cb4fe9050"
-          # darwin-x86_64
-          EXPECTED_SUM2="3e8692fa751983b75b11392968b6244e48b8b56a3363257286840ac35a696c06"
-          CHECKSUM="$(sha256sum "${SFSIGNER0_EXE}" | cut -f1 -d' ')"
-          [ "$CHECKSUM" = "$EXPECTED_SUM1" ] || [ "$CHECKSUM" = "$EXPECTED_SUM2" ] || exit 1
-          chmod +x "${SFSIGNER0_EXE}"
-          "${SFSIGNER0_EXE}" version
+          ./bin/hermit env -r >> $GITHUB_ENV
 
       - name: Build at tagged revision
         run: |
@@ -70,14 +53,15 @@ jobs:
           fi
           mv build/sfsigner build/sfsigner-"$OS"-"$ARCH"
 
-      - name: Sign artifact using sfsigner v0.0.0
+      - name: Sign artifact using Hermit managed sfsigner
         run: |
           set -euxo pipefail
           cd ${{ github.workspace }}
           EXE="build/sfsigner-${OS}-${ARCH}"
-          "${SFSIGNER0_EXE}" sign -c data/certs/sfsigner.pem -o "${EXE}.sig" "${EXE}"
+          sfsigner version
+          sfsigner sign -c data/certs/sfsigner.pem -o "${EXE}.sig" "${EXE}"
           # Self-check: verify signature
-          "${SFSIGNER0_EXE}" verify -p "${EXE}" -s "${EXE}.sig" -c data/certs/sfsigner.pem -t data/ca.pem
+          sfsigner verify -p "${EXE}" -s "${EXE}.sig" -c data/certs/sfsigner.pem -t data/ca.pem
         env:
           SFSIGNER_PRIVATE_KEY: ${{ secrets.SFSIGNER_PRIVATE_KEY }}
 

--- a/bin/hermit
+++ b/bin/hermit
@@ -22,7 +22,20 @@ export HERMIT_EXE=${HERMIT_EXE:-${HERMIT_STATE_DIR}/pkg/hermit@${HERMIT_CHANNEL}
 
 if [ ! -x "${HERMIT_EXE}" ]; then
   echo "Bootstrapping ${HERMIT_EXE} from ${HERMIT_DIST_URL}" 1>&2
-  curl -fsSL "${HERMIT_DIST_URL}/install.sh" | /bin/bash 1>&2
+  INSTALL_SCRIPT="$(mktemp)"
+  # This value must match that of the install script
+  INSTALL_SCRIPT_SHA256="180e997dd837f839a3072a5e2f558619b6d12555cd5452d3ab19d87720704e38"
+  if [ "${INSTALL_SCRIPT_SHA256}" = "BYPASS" ]; then
+    curl -fsSL "${HERMIT_DIST_URL}/install.sh" -o "${INSTALL_SCRIPT}"
+  else
+    # Install script is versioned by its sha256sum value
+    curl -fsSL "${HERMIT_DIST_URL}/install-${INSTALL_SCRIPT_SHA256}.sh" -o "${INSTALL_SCRIPT}"
+    # Verify install script's sha256sum
+    openssl dgst -sha256 "${INSTALL_SCRIPT}" | \
+      awk -v EXPECTED="$INSTALL_SCRIPT_SHA256" \
+      '$2!=EXPECTED {print "Install script sha256 " $2 " does not match " EXPECTED; exit 1}'
+  fi
+  /bin/bash "${INSTALL_SCRIPT}" 1>&2
 fi
 
 exec "${HERMIT_EXE}" --level=fatal exec "$0" -- "$@"


### PR DESCRIPTION
This version is security hardened, in that bin/hermit checks the
installer script's hash value before executing it.

Use Hermit to manage sfsigner version in release pipeline