### PR TITLE
Unify subcommand options convention for sign and verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,10 @@ make clean
 
      Available commands:
        version                  Show version
-       sign                     Sign file
-       verify                   Verify signature
+       sign                     Sign payload file.
+         Private signing key is obtained from environment variable
+         SFSIGNER_PRIVATE_KEY. Only RSA keys are supported currently.
+       verify                   Verify signature of payload file
      ```
 
    - Example signing commands
@@ -69,13 +71,13 @@ make clean
 
      ```bash
      # Use test data. Should get "Verification: success"
-     build/sfsigner verify --payload test/payload.txt \
+     build/sfsigner verify test/payload.txt \
        --signature test/signature.pem \
        --cert test/certificate.pem \
        --cacert test/cacert.pem
      # If cacert is not present, skip chanined verification. Should get
      # "Verification: success"
-     build/sfsigner verify --payload test/payload.txt \
+     build/sfsigner verify test/payload.txt \
        --signature test/signature.pem \
        --cert test/certificate.pem
      ```

--- a/script/sign-and-verify.sh
+++ b/script/sign-and-verify.sh
@@ -29,11 +29,11 @@ for i in $(seq 20); do
   echo "Signature is written to ${sig}"
 
   echo "Verify payload against good signature"
-  "${SFSIGNER_EXE}" verify -p "${payload}" -s "${sig}" -c "${CERT_FILE}"
+  "${SFSIGNER_EXE}" verify "${payload}" -s "${sig}" -c "${CERT_FILE}"
 
   echo "Verify payload against bad signature"
   echo "A" >> "${payload}"
-  if ! "${SFSIGNER_EXE}" verify -p "${payload}" -s "${sig}" -c "${CERT_FILE}"; then
+  if ! "${SFSIGNER_EXE}" verify "${payload}" -s "${sig}" -c "${CERT_FILE}"; then
     echo "Tampered payload failed signature verification as expected"
   else
     exit 1

--- a/src/CliLib.hs
+++ b/src/CliLib.hs
@@ -24,11 +24,15 @@ versionParser =
 
 signParser :: Parser (IO ())
 signParser =
-  subcommand "sign" "Sign file" parseSign
+  subcommand "sign"
+    "Sign payload file.\n\
+    \    Private signing key is obtained from environment variable\n\
+    \    SFSIGNER_PRIVATE_KEY. Only RSA keys are supported currently."
+    parseSign
 
 verifyParser :: Parser (IO ())
 verifyParser =
-  subcommand "verify" "Verify signature" parseVerify
+  subcommand "verify" "Verify signature of payload file" parseVerify
 
 -- "version" subcommand options
 version' :: IO ()
@@ -45,7 +49,7 @@ data SettingsSignCmd = SettingsSignCmd
   }
 
 payloadParser :: Parser FilePath
-payloadParser = argPath "payload" "The payload file to sign"
+payloadParser = argPath "payload" "The payload file to sign or verify"
 
 certificateParser :: Parser FilePath
 certificateParser = optPath "cert" 'c' "Signer's X509 certificate in PEM"
@@ -80,9 +84,6 @@ data SettingsVerifyCmd = SettingsVerifyCmd
   , settingsVerifyCmdCACert      :: Maybe FilePath
   }
 
-payloadParser' :: Parser FilePath
-payloadParser' = optPath "payload" 'p' "The payload file to verify"
-
 signatureParser :: Parser FilePath
 signatureParser = optPath "signature" 's' "The PKCS#7 signature in PEM"
 
@@ -92,7 +93,7 @@ cacertParser = optional (optPath "cacert" 't'
 
 settingsVerifyCmdParser :: Parser SettingsVerifyCmd
 settingsVerifyCmdParser =
-  SettingsVerifyCmd <$> payloadParser'
+  SettingsVerifyCmd <$> payloadParser
                     <*> signatureParser
                     <*> certificateParser
                     <*> cacertParser


### PR DESCRIPTION
Remove the `-p`/`--payload` option for the payload file for `verify`.
This matches the convention for subcommand `sign`.

Also update documentation and test script to incorporate this change.

Make it clear in online help message that the private signing key is
obtained from an environment variable.