### PR TITLE
Refactor r10e-static-build

### DIFF
--- a/r10e-static-build/Dockerfile
+++ b/r10e-static-build/Dockerfile
@@ -51,8 +51,9 @@ COPY r10e-static-build/default.nix /build/default.nix
 # Step 3: Build final artifact
 #########################################################
 
-RUN $(export NIXPATH=nixpkgs=/build/nixpkgs; \
-  nix-build --no-link -A fullBuildScript \
+RUN BUILD_SCRIPT=$(nix-build --no-link -A fullBuildScript \
+  -j auto \
   --argstr src-dir ${PWD}/sf-signer \
   --argstr package-name sf-signer \
-  --argstr static-haskell-nix-dir ${PWD}/static-haskell-nix)
+  --argstr static-haskell-nix-dir ${PWD}/static-haskell-nix) && \
+  ${BUILD_SCRIPT}

--- a/stack.yaml
+++ b/stack.yaml
@@ -66,7 +66,3 @@ system-ghc: true
 #
 # Allow a newer minor version of GHC than the snapshot specifies
 # compiler-check: newer-minor
-nix:
-  enable: false
-  pure: false
-  shell-file: shell.nix


### PR DESCRIPTION
Fix a bug, and let NIX_PATH drive nixpkgs.

There's still a reproducibility problem with the current setting. The
build even fails on an Ubuntu system. This refactor helpfully will be
useful in narrowing down the issue.