### PR TITLE
Skip certificate expiration check in chained verification

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -22,12 +22,14 @@ jobs:
         run: |
           if [ ${{ matrix.os }} = 'ubuntu-latest' ]; then
             sudo apt-get update
+            sudo apt-get install -y faketime
           fi
           sudo curl -sSL https://get.haskellstack.org/ | sh -s - -f
           stack --version
           if [ ${{ matrix.os }} = 'macos-latest' ]; then
             # for `sha256sum`
             brew install coreutils
+            brew install libfaketime
           fi
       - name: Build
         run: |

--- a/.github/workflows/verify-certificate-chain.yml
+++ b/.github/workflows/verify-certificate-chain.yml
@@ -27,5 +27,13 @@ jobs:
             | sha256sum -c --status || \
             { echo "error: data/ca.pem may be tampered with"; exit 1; }
           for f in $(find data/certs -name *.pem -type f); do
+            cert_expiry="$(openssl x509 -enddate -noout -in "${f}" | cut -f2 -d'=')"
+            cert_expiry_unix_ts="$(date --date "${cert_expiry}" "+%s")"
+            now_unix_ts="$(date +%s --utc)"
+            # Info about cert expiry. Do not fail.
+            [ "$cert_expiry_unix_ts" -gt "$now_unix_ts" ] \
+              || echo "Info: Certificate ${f} expired on ${cert_expiry}"
+            # Skip certificate expiration check by manipulating attime
+            attime=$(( cert_expiry_unix_ts - 1 ))
             openssl verify -CAfile data/ca.pem "$f"
           done

--- a/.github/workflows/verify-certificate-chain.yml
+++ b/.github/workflows/verify-certificate-chain.yml
@@ -35,5 +35,5 @@ jobs:
               || echo "Info: Certificate ${f} expired on ${cert_expiry}"
             # Skip certificate expiration check by manipulating attime
             attime=$(( cert_expiry_unix_ts - 1 ))
-            openssl verify -CAfile data/ca.pem "$f"
+            openssl verify -CAfile data/ca.pem -attime "${attime}" "$f"
           done

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,11 @@ build_options_static := $(mkfile_dir)/build-options-static.yaml
 build_options_dynamic := $(mkfile_dir)/build-options-dynamic.yaml
 stack_yaml := STACK_YAML="$(mkfile_dir)/stack.yaml"
 stack := $(stack_yaml) stack
+# Workaround the expiry of hardcoded test certificate in test/Spec.hs,
+# which expires on Dec 20 20:10:47 2023 GMT, one second after the faketime.
+# The expiration time of the certificate is obtained with command
+#     openssl x509 -enddate -in /path/to/cert-file -noout
+stack_faketime := $(stack_yaml) faketime "Dec 20 20:10:46 2023 GMT" stack
 
 export PATH := $(PATH):$(build_dir)
 
@@ -23,7 +28,7 @@ static-build:
 	$(stack) --copy-bins --local-bin-path build build $(package)
 
 test:
-	$(stack) test $(package)
+	$(stack_faketime) test $(package)
 
 clean:
 	rm -rf $(build_dir) $(mkfile_dir)/.stack-work


### PR DESCRIPTION
This slight security downgrade is for ease of certificate management.
With the assumption that the leaf signing certificates are in the TCB,
not failing hard on expired cert in code signing seems to be a
reasonable compromise.